### PR TITLE
Fix sync schedule setting id in base.html

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -167,7 +167,7 @@
           </div>
           <div class="form-group-modal my-2">
             <label for="sync-schedule">Sync Schedule:</label>
-            <input type="text" class="form-control" id="sync_start_times"
+            <input type="text" class="form-control" id="sync-schedule"
               placeholder="Enter Hour in 24hr format (use , for multiple hours)">
           </div>
           <div class="form-group-modal">


### PR DESCRIPTION
wrong id (likely typo) is causing load_settings and update_settings to throw exception and fail because of null value