### PR TITLE
added try around get request in download function

### DIFF
--- a/src/BookBounty.py
+++ b/src/BookBounty.py
@@ -532,7 +532,15 @@ class DataHandler:
                 file_type = None
                 self.general_logger.info("File extension not in url or invalid, checking link content...")
 
-        dl_resp = requests.get(link_url, stream=True)
+        try:
+            dl_resp = requests.get(link_url, stream=True)        
+        except Exception as e:
+            req_item["status"] = "Link Failed"
+            socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+            error_string = f"Exception {e} thrown by: {link_url}"
+            self.general_logger.error(error_string)
+            return "Link Failed"
+        
         if file_type == None or ".php" in file_type:
             link_file_name_text = dl_resp.headers.get("content-disposition")
             if not link_file_name_text:


### PR DESCRIPTION
I was getting a lot of download failures, and looking at the logs it seemed like only one link was being tried. I debugged and noticed that even though there were multiple links being found in _link_finder, the download was in fact getting marked as failed and moving on to the next book after the first link. With this change, I got a lot more successful downloads and I think it could be a potential fix/workaround to issue #9, as this was also an error message I was getting a lot on the first mirror link.

Feel free to edit the error logging, socket code, and coding style.