### PR TITLE
Docker Environment Variable for Port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,15 @@ FROM python:3.12-alpine
 # Set build arguments
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}
+ENV BB_PORT=${BB_PORT:-5000}
 
 # Create User
 ARG UID=1000
 ARG GID=1000
 RUN addgroup -g $GID general_user && \
     adduser -D -u $UID -G general_user -s /bin/sh general_user
+
+RUN apk --no-cache --no-interactive update && apk --no-cache --no-interactive upgrade
 
 # Create directories and set permissions
 COPY . /bookbounty
@@ -18,7 +21,8 @@ RUN chown -R $UID:$GID /bookbounty
 RUN chmod -R 777 /bookbounty/downloads
 
 # Install requirements and run code as general_user
-RUN pip install --no-cache-dir -r requirements.txt
-EXPOSE 5000
+RUN pip install --root-user-action=ignore --no-cache-dir --upgrade pip && \
+    pip install --root-user-action=ignore --no-cache-dir -r requirements.txt
+EXPOSE ${BB_PORT}
 USER general_user
-CMD ["gunicorn","src.BookBounty:app", "-c", "gunicorn_config.py"]
+CMD exec gunicorn src.BookBounty:app -b 0.0.0.0:${BB_PORT} -c gunicorn_config.py

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,4 +1,3 @@
-bind = "0.0.0.0:5000"
 workers = 1
 threads = 4
 timeout = 120

--- a/src/BookBounty.py
+++ b/src/BookBounty.py
@@ -780,4 +780,4 @@ def update_settings(data):
 
 
 if __name__ == "__main__":
-    socketio.run(app, host="0.0.0.0", port=5000)
+    socketio.run(app)


### PR DESCRIPTION
Same as https://github.com/TheWicklowWolf/eBookBuddy/pull/5

Allows users to set BB_PORT to the desired Port. Defaults to 5000 if not set.

Fixes #5 

Example Docker Compose:
```
services:
  bookbounty:
    image: thewicklowwolf/bookbounty:latest
    container_name: bookbounty
    network_mode: service:vpn
    restart: unless-stopped
    ports:
      - 5011:5011
    environment:
      BB_PORT: 5011
      readarr_address: http://vpn:8788
      readarr_api_key: 1234567890
      sync_schedule: 2, 20
      library_scan_on_completion: True
    volumes:
      - /path/to/config:/bookbounty/config
      - /path/to/downloads:/bookbounty/downloads
      - /etc/localtime:/etc/localtime:ro
```