### PR TITLE
Changed language logic to use book MetadataProfile from readarr, and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Certain values can be set via environment variables:
 * __library_scan_on_completion__: Whether to scan Readarr Library on completion. Defaults to `True`.
 * __request_timeout__: Timeout for requests (seconds). Defaults to `120`.
 * __thread_limit__: Max number of threads to use. Defaults to `1`.
-* __selected_language__: Filter download by language (specific language or all). Defaults to `English`.
+* __selected_language__: Filter download by languages (specific languages or all). Defaults to `English`. This is used if BookBounty is unable to get the languages from the Readarr Metadata Profile.
 * __preferred_extensions_fiction__: Filter fiction download by extension (comma separated). Defaults to `.epub, .mobi, .azw3, .djvu`.
 * __preferred_extensions_non_fiction__: Filter non-fiction download by extension (comma separated). Defaults to `.pdf .epub, .mobi, .azw3, .djvu`.
 * __search_last_name_only__: Use only the author's last name in searches. Defaults to `False`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 libgen_api
 unidecode
 thefuzz
+iso639-lang


### PR DESCRIPTION
I changed the language check logic to use the book MetadataProfile from readarr. Since readarr languages allow a comma separated list, I also changed the BookBounty setting to match instead of using only a single option for config.

I had set my language option to "All" because my family and I read books in a couple different languages, but one of the books got a version in a language I don't know. In readarr you can use Profiles to specify the allowed languages so I added an api call to query it. I still kept the config setting as a fallback in case people don't use the readarr language option. 

Feel free to modify as you like or not merge it. I found it useful for my needs.