### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-handler.yml
+++ b/.github/workflows/issue-handler.yml
@@ -1,4 +1,6 @@
 name: Close Non-Bug Issues
+permissions:
+  issues: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/TheWicklowWolf/BookBounty/security/code-scanning/1](https://github.com/TheWicklowWolf/BookBounty/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the workflow only needs to close issues and add comments, the minimal required permission is `issues: write`. This can be set at the job level (for `close-issue-if-not-bug`) or at the workflow root (to apply to all jobs). The best practice is to add it at the workflow root unless some jobs require different permissions. In this case, adding the following at the top level (after `name:` and before `on:`) is sufficient:

```yaml
permissions:
  issues: write
```

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
