### PR TITLE
Add corrections for Libgen format 2

### DIFF
--- a/.github/workflows/develop_build.yml
+++ b/.github/workflows/develop_build.yml
@@ -3,6 +3,7 @@ permissions:
   contents: read
 
 on:
+  push:
     branches:
       - develop
     paths-ignore:

--- a/.github/workflows/develop_build.yml
+++ b/.github/workflows/develop_build.yml
@@ -1,7 +1,8 @@
 name: develop-ci
+permissions:
+  contents: read
 
 on:
-  push:
     branches:
       - develop
     paths-ignore:

--- a/.github/workflows/develop_build.yml
+++ b/.github/workflows/develop_build.yml
@@ -1,0 +1,44 @@
+name: develop-ci
+
+on:
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  build-develop-docker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Convert repository name to lowercase
+        id: lowercase_repo
+        run: |
+          REPO_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+          echo "REPO_NAME=$REPO_NAME" >> $GITHUB_ENV
+
+      - name: Build and push develop image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.REPO_NAME }}:develop

--- a/.github/workflows/issue-handler.yml
+++ b/.github/workflows/issue-handler.yml
@@ -1,4 +1,6 @@
 name: Close Non-Bug Issues
+permissions:
+  issues: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: ci
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -9,6 +12,8 @@ on:
 
 jobs:
   bump-version-and-create-release-tag:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/src/BookBounty.py
+++ b/src/BookBounty.py
@@ -9,12 +9,13 @@ import threading
 import concurrent.futures
 import iso639
 import requests
+from src.aaclient import aaclient
 from flask import Flask, render_template
 from flask_socketio import SocketIO
 from bs4 import BeautifulSoup
 from thefuzz import fuzz
 from libgen_api import LibgenSearch
-
+import urllib.parse
 
 class DataHandler:
     def __init__(self):
@@ -38,13 +39,16 @@ class DataHandler:
         self.libgen_stop_event = threading.Event()
         self.libgen_thread_lock = threading.Lock()
 
-        self.libgen_in_progress_flag = False
+        self.libgen_in_progress_flag = False        
+        self.is_using_libgen_api = False
         self.index = 0
         self.percent_completion = 0
 
         self.clients_connected_counter = 0
         self.config_folder = "config"
         self.download_folder = "downloads"
+        self.aa_client_type = ""
+        self.aaclient = None
 
         if not os.path.exists(self.config_folder):
             os.makedirs(self.config_folder)
@@ -58,10 +62,8 @@ class DataHandler:
             "readarr_address": "http://192.168.1.2:8787",
             "readarr_api_key": "",
             "request_timeout": 120.0,
-            "libgen_address": "http://libgen.is",
             "thread_limit": 1,
             "sleep_interval": 0,
-            "search_type": "fiction",
             "library_scan_on_completion": True,
             "sync_schedule": [],
             "minimum_match_ratio": 90,
@@ -76,7 +78,6 @@ class DataHandler:
         # Load settings from environmental variables (which take precedence) over the configuration file.
         self.readarr_address = os.environ.get("readarr_address", "")
         self.readarr_api_key = os.environ.get("readarr_api_key", "")
-        self.libgen_address = os.environ.get("libgen_address", "")
         sync_schedule = os.environ.get("sync_schedule", "")
         self.sync_schedule = self.parse_sync_schedule(sync_schedule) if sync_schedule != "" else ""
         sleep_interval = os.environ.get("sleep_interval", "")
@@ -84,7 +85,6 @@ class DataHandler:
         minimum_match_ratio = os.environ.get("minimum_match_ratio", "")
         self.minimum_match_ratio = float(minimum_match_ratio) if minimum_match_ratio else ""
         self.selected_path_type = os.environ.get("selected_path_type", "")
-        self.search_type = os.environ.get("search_type", "")
         library_scan_on_completion = os.environ.get("library_scan_on_completion", "")
         self.library_scan_on_completion = library_scan_on_completion.lower() == "true" if library_scan_on_completion != "" else ""
         search_last_name_only = os.environ.get("search_last_name_only", "")
@@ -100,6 +100,7 @@ class DataHandler:
         self.preferred_extensions_fiction = preferred_extensions_fiction.split(",") if preferred_extensions_fiction else ""
         preferred_extensions_non_fiction = os.environ.get("preferred_extensions_non_fiction", "")
         self.preferred_extensions_non_fiction = preferred_extensions_non_fiction.split(",") if preferred_extensions_non_fiction else ""
+        self.aa_client_type = os.environ.get("aa_client_type", "")
 
         # Load variables from the configuration file if not set by environmental variables.
         try:
@@ -122,6 +123,7 @@ class DataHandler:
 
         # Save config.
         self.save_config_to_file()
+        self.update_aaclient_settings()
 
         # Start Scheduler
         thread = threading.Thread(target=self.schedule_checker, name="Schedule_Thread")
@@ -135,12 +137,10 @@ class DataHandler:
                     {
                         "readarr_address": self.readarr_address,
                         "readarr_api_key": self.readarr_api_key,
-                        "libgen_address": self.libgen_address,
                         "sleep_interval": self.sleep_interval,
                         "sync_schedule": self.sync_schedule,
                         "minimum_match_ratio": self.minimum_match_ratio,
                         "selected_path_type": self.selected_path_type,
-                        "search_type": self.search_type,
                         "library_scan_on_completion": self.library_scan_on_completion,
                         "request_timeout": self.request_timeout,
                         "thread_limit": self.thread_limit,
@@ -149,6 +149,7 @@ class DataHandler:
                         "preferred_extensions_non_fiction": self.preferred_extensions_non_fiction,
                         "search_last_name_only": self.search_last_name_only,
                         "search_shortened_title": self.search_shortened_title,
+                        "aa_client_type": self.aa_client_type,
                     },
                     json_file,
                     indent=4,
@@ -344,39 +345,89 @@ class DataHandler:
             socketio.emit("new_toast_msg", {"title": "End of Session", "message": f"Downloading {self.libgen_status.capitalize()}"})
 
     def find_link_and_download(self, req_item):
-        try:
-            req_item["status"] = "Searching..."
-            socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
-            search_results = self._link_finder(req_item)
-            if self.libgen_stop_event.is_set():
-                return
-
-            if search_results:
-                req_item["status"] = "Link Found"
+        finder_functions = [
+            self._link_finder_annas_archive,
+            self._link_finder_libgen_li,
+            self._link_finder_libgen_api, 
+            self._link_finder_libgen_is, 
+            ]
+        
+        for func in finder_functions:
+            try:                
+                self.is_using_libgen_api = False
+                req_item["status"] = "Searching..."
                 socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
-                for link in search_results:
-                    ret = self.download_from_libgen(req_item, link)
-                    if ret == "Success":
-                        req_item["status"] = "Download Complete"
-                        break
-                    elif ret == "Already Exists":
-                        req_item["status"] = "File Already Exists"
-                        break
-                else:
-                    req_item["status"] = ret
+                search_results = func(req_item)
+                if self.libgen_stop_event.is_set():
+                    return
+
+                if search_results:
+                    req_item["status"] = "Link Found"
+                    socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+                    for link in search_results:
+                        ret = self.download_from_mirror(req_item, link)
+                        if ret == "Success":
+                            req_item["status"] = "Download Complete"
+                            break
+                        elif ret == "Already Exists":
+                            req_item["status"] = "File Already Exists"
+                            break
+                    else:
+                        req_item["status"] = ret
+            
+                if req_item["status"] == "Download Complete":
+                    break
+
+            except Exception as e:
+                self.general_logger.error(f"Error Downloading: {str(e)}")
+                req_item["status"] = "Download Error"
+
+        self.index += 1
+        self.percent_completion = 100 * (self.index / len(self.libgen_items)) if self.libgen_items else 0
+        socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+
+    def _link_finder_libgen_api(self, req_item):
+        try:
+            self.general_logger.warning(f'Searching API for Book: {req_item["author"]} - {req_item["book_name"]} - Allowed Languages: {",".join(req_item["allowed_languages"])}')
+            author = req_item["author"]
+            book_name = req_item["book_name"]
+            book_search_text = book_name.split(":")[0] if self.search_shortened_title else book_name
+
+            found_links = []
+
+            try:
+                with self.libgen_thread_lock:
+                    s = LibgenSearch()
+                    results = s.search_title(book_search_text)
+                    self.general_logger.warning(f"Found {len(results)} potential matches")
+
+            except Exception as e:
+                self.general_logger.error(f"Error with libgen_api search library: {str(e)}")
+                results = None
+
+            for item in results:
+                author_name_match_ratio = self.compare_author_names(item["Author"], author)
+                book_name_match_ratio = fuzz.ratio(item["Title"], book_name)
+                average_match_ratio = (author_name_match_ratio + book_name_match_ratio) / 2
+                language_check = item["Language"].lower() in req_item["allowed_languages"] or self.selected_language.lower() == "all"
+                if average_match_ratio > self.minimum_match_ratio and language_check:
+                    download_links = s.resolve_download_links(item)
+                    found_links = [value for value in download_links.values()]
+                    break
+            else:
+                req_item["status"] = "No Link Found"
 
         except Exception as e:
-            self.general_logger.error(f"Error Downloading: {str(e)}")
-            req_item["status"] = "Download Error"
+            self.general_logger.error(f"Error Searching libgen API: {str(e)}")
+            raise Exception(f"Error Searching libgen API: {str(e)}")
 
         finally:
-            self.index += 1
-            self.percent_completion = 100 * (self.index / len(self.libgen_items)) if self.libgen_items else 0
-            socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+            self.is_using_libgen_api = True
+            return found_links
 
-    def _link_finder(self, req_item):
+    def _link_finder_libgen_is(self, req_item):
         try:
-            self.general_logger.warning(f'Searching for Book: {req_item["author"]} - {req_item["book_name"]} - Allowed Languages: {",".join(req_item["allowed_languages"])}')
+            self.general_logger.warning(f'Searching libgen.is for Book: {req_item["author"]} - {req_item["book_name"]} - Allowed Languages: {",".join(req_item["allowed_languages"])}')
             author = req_item["author"]
             book_name = req_item["book_name"]
 
@@ -385,99 +436,252 @@ class DataHandler:
             query_text = f"{author_search_text} - {book_search_text}"
 
             found_links = []
-
-            if self.search_type.lower() == "non-fiction":
-                try:
-                    with self.libgen_thread_lock:
-                        s = LibgenSearch()
-                        results = s.search_title(book_search_text)
-                        self.general_logger.warning(f"Found {len(results)} potential matches")
-
-                except Exception as e:
-                    self.general_logger.error(f"Error with libgen_api search library: {str(e)}")
-                    results = None
-
-                for item in results:
-                    author_name_match_ratio = self.compare_author_names(item["Author"], author)
-                    book_name_match_ratio = fuzz.ratio(item["Title"], book_name)
-                    average_match_ratio = (author_name_match_ratio + book_name_match_ratio) / 2
-                    language_check = item["Language"].lower() in req_item["allowed_languages"] or self.selected_language.lower() == "all"
-                    if average_match_ratio > self.minimum_match_ratio and language_check:
-                        download_links = s.resolve_download_links(item)
-                        found_links = [value for value in download_links.values()]
-                        break
+            search_item = query_text.replace(" ", "+")
+            url = f"http://libgen.is/fiction/?q={search_item}"
+            response = requests.get(url, timeout=self.request_timeout)
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.text, "html.parser")
+                table = soup.find("tbody")
+                if table:
+                    rows = table.find_all("tr")
                 else:
-                    req_item["status"] = "No Link Found"
+                    rows = []
 
-            else:
-                search_item = query_text.replace(" ", "+")
-                url = f"{self.libgen_address}/fiction/?q={search_item}"
-                response = requests.get(url, timeout=self.request_timeout)
-                if response.status_code == 200:
-                    soup = BeautifulSoup(response.text, "html.parser")
-                    table = soup.find("tbody")
-                    if table:
-                        rows = table.find_all("tr")
-                    else:
-                        rows = []
-
-                    for row in rows:
+                for row in rows:
+                    try:
+                        cells = row.find_all("td")
                         try:
-                            cells = row.find_all("td")
-                            try:
-                                author_string = cells[0].get_text().strip()
-                            except:
-                                author_string = ""
-                            try:
-                                raw_title = cells[2].get_text().strip()
-                                if "\nISBN" in raw_title:
-                                    title_string = raw_title.split("\nISBN")[0]
-                                elif "\nASIN" in raw_title:
-                                    title_string = raw_title.split("\nASIN")[0]
-                                else:
-                                    title_string = raw_title
-                            except:
-                                title_string = ""
-                            try:
-                                language = cells[3].get_text().strip()
-                            except:
-                                language = "english"
-                            try:
-                                file_type = cells[4].get_text().strip().lower()
-                            except:
-                                file_type = ".epub"
-                            file_type_check = any(ft.replace(".", "").lower() in file_type for ft in self.preferred_extensions_fiction)
-                            language_check = language.lower() in req_item["allowed_languages"] or self.selected_language.lower() == "all"
-
-                            if file_type_check and language_check:
-                                author_name_match_ratio = self.compare_author_names(author, author_string)
-                                book_name_match_ratio = fuzz.ratio(title_string, book_search_text)
-                                if author_name_match_ratio >= self.minimum_match_ratio and book_name_match_ratio >= self.minimum_match_ratio:
-                                    mirrors = row.find("ul", class_="record_mirrors_compact")
-                                    links = mirrors.find_all("a", href=True)
-                                    for link in links:
-                                        href = link["href"]
-                                        if href.startswith("http://") or href.startswith("https://"):
-                                            found_links.append(href)
+                            author_string = cells[0].get_text().strip()
                         except:
-                            pass
+                            author_string = ""
+                        try:
+                            raw_title = cells[2].get_text().strip()
+                            if "\nISBN" in raw_title:
+                                title_string = raw_title.split("\nISBN")[0]
+                            elif "\nASIN" in raw_title:
+                                title_string = raw_title.split("\nASIN")[0]
+                            else:
+                                title_string = raw_title
+                        except:
+                            title_string = ""
+                        try:
+                            language = cells[3].get_text().strip()
+                        except:
+                            language = "english"
+                        try:
+                            file_type = cells[4].get_text().strip().lower()
+                        except:
+                            file_type = ".epub"
+                        file_type_check = any(ft.replace(".", "").lower() in file_type for ft in self.preferred_extensions_fiction)
+                        language_check = language.lower() in req_item["allowed_languages"] or self.selected_language.lower() == "all"
 
-                    if not found_links:
-                        req_item["status"] = "No Link Found"
-                    socketio.emit("libgen_update", {"status": "Success", "data": self.libgen_items, "percent_completion": self.percent_completion})
-                else:
-                    socketio.emit("libgen_update", {"status": "Error", "data": self.libgen_items, "percent_completion": self.percent_completion})
-                    self.general_logger.error("Libgen Connection Error: " + str(response.status_code) + " Data: " + response.text)
-                    req_item["status"] = "Libgen Error"
-                    socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+                        if file_type_check and language_check:
+                            author_name_match_ratio = self.compare_author_names(author, author_string)
+                            book_name_match_ratio = fuzz.ratio(title_string, book_search_text)
+                            if author_name_match_ratio >= self.minimum_match_ratio and book_name_match_ratio >= self.minimum_match_ratio:
+                                mirrors = row.find("ul", class_="record_mirrors_compact")
+                                links = mirrors.find_all("a", href=True)
+                                for link in links:
+                                    href = link["href"]
+                                    if href.startswith("http://") or href.startswith("https://"):
+                                        found_links.append(href)
+                    except:
+                        pass
+
+                if not found_links:
+                    req_item["status"] = "No Link Found"
+                socketio.emit("libgen_update", {"status": "Success", "data": self.libgen_items, "percent_completion": self.percent_completion})
+            else:
+                socketio.emit("libgen_update", {"status": "Error", "data": self.libgen_items, "percent_completion": self.percent_completion})
+                self.general_logger.error("Libgen Connection Error: " + str(response.status_code) + " Data: " + response.text)
+                req_item["status"] = "Libgen Error"
+                socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
 
         except Exception as e:
-            self.general_logger.error(f"Error Searching libgen: {str(e)}")
-            raise Exception(f"Error Searching libgen: {str(e)}")
+            self.general_logger.error(f"Error Searching libgen.is: {str(e)}")
+            raise Exception(f"Error Searching libgen.is: {str(e)}")
 
         finally:
             return found_links
 
+    def _link_finder_libgen_li(self, req_item):
+        try:
+            self.general_logger.warning(f'Searching libgen.li for Book: {req_item["author"]} - {req_item["book_name"]} - Allowed Languages: {",".join(req_item["allowed_languages"])}')
+            author = req_item["author"]
+            book_name = req_item["book_name"]
+
+            author_search_text = f"{author.split(' ')[-1]}" if self.search_last_name_only else author
+            book_search_text = book_name.split(":")[0] if self.search_shortened_title else book_name
+            query_text = f"{author_search_text} - {book_search_text}"
+
+            found_links = []
+            search_item= urllib.parse.quote(query_text)
+            url = f"http://libgen.bz/index.php?req={search_item}"
+            self.general_logger.warning(f'Search Url: {url} ')
+            response = requests.get(url, timeout=self.request_timeout)
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.text, "html.parser")
+                table = soup.find("tbody")
+                if table:
+                    rows = table.find_all("tr")
+                else:
+                    rows = []
+
+                for row in rows:
+                    try:
+                        cells = row.find_all("td")
+                        try:
+                            author_string = cells[1].get_text().strip()
+                        except:
+                            author_string = ""
+                        try:
+                            a_tags = cells[0].find_all("a")
+                            raw_title = ""
+                            for a in a_tags:
+                                text = a.get_text().strip()
+                                if text:
+                                    raw_title = text
+                                    break
+                            if "\nISBN" in raw_title:
+                                title_string = raw_title.split("\nISBN")[0]
+                            elif "\nASIN" in raw_title:
+                                title_string = raw_title.split("\nASIN")[0]
+                            else:
+                                title_string = raw_title
+                        except:
+                            title_string = ""
+                        self.general_logger.warning(f"Title String: {title_string}")
+                        try:
+                            language = cells[4].get_text().strip()
+                        except:
+                            language = "english"
+                        try:
+                            file_type = cells[7].get_text().strip().lower()
+                        except:
+                            file_type = ".epub"
+                        file_type_check = any(ft.replace(".", "").lower() in file_type for ft in self.preferred_extensions_fiction)
+                        language_check = language.lower() in req_item["allowed_languages"] or self.selected_language.lower() == "all"
+
+                        if file_type_check and language_check:
+                            author_name = author.strip()
+
+                            # Format 1: Firstname Lastname (original)
+                            author_format1 = author_name
+
+                            # Format 2: Lastname, Firstname
+                            parts = author_name.split()
+                            if len(parts) >= 2:
+                                firstname = " ".join(parts[:-1])
+                                lastname = parts[-1]
+                                author_format2 = f"{lastname}, {firstname}"
+                            else:
+                                author_format2 = author_name  # fallback to original if can't split properly
+
+                            # Compare both formats
+                            ratio1 = self.compare_author_names(author_format1, author_string)
+                            ratio2 = self.compare_author_names(author_format2, author_string)
+
+                            # Pick best match
+                            author_name_match_ratio = max(ratio1, ratio2)
+
+                            # Book title match as before
+                            book_name_match_ratio = fuzz.ratio(title_string, book_search_text)
+                            if author_name_match_ratio >= self.minimum_match_ratio and book_name_match_ratio >= self.minimum_match_ratio:
+                                mirrors = cells[8]
+                                links = mirrors.find_all("a", href=True)
+                                for link in links:
+                                    href = link["href"]
+                                    if href.startswith("http://") or href.startswith("https://"):
+                                        found_links.append(href)
+                                    elif href.startswith("/"):
+                                        found_links.append("http://libgen.li" + href)
+                    except:
+                        pass
+
+                if not found_links:
+                    req_item["status"] = "No Link Found"
+                socketio.emit("libgen_update", {"status": "Success", "data": self.libgen_items, "percent_completion": self.percent_completion})
+            else:
+                socketio.emit("libgen_update", {"status": "Error", "data": self.libgen_items, "percent_completion": self.percent_completion})
+                self.general_logger.error("Libgen Connection Error: " + str(response.status_code) + " Data: " + response.text)
+                req_item["status"] = "Libgen Error"
+                socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+        
+        except Exception as e:
+            self.general_logger.error(f"Error Searching libgen.li: {str(e)}")
+            raise Exception(f"Error Searching libgen.li: {str(e)}")
+
+        finally:
+            return found_links
+
+    def _link_finder_annas_archive(self, req_item):
+        if (self.aaclient is None):
+            return []
+        try:
+            self.general_logger.warning(f'Searching annas-archive for Book: {req_item["author"]} - {req_item["book_name"]} - Allowed Languages: {",".join(req_item["allowed_languages"])}')
+            author = req_item["author"]
+            book_name = req_item["book_name"]
+
+            author_search_text = f"{author.split(' ')[-1]}" if self.search_last_name_only else author
+            book_search_text = book_name.split(":")[0] if self.search_shortened_title else book_name
+            query_text = f"{author_search_text} - {book_search_text}"
+
+            found_links = []
+            search_item = query_text.replace(" ", "+")
+            url = f"http://annas-archive.org/search?index=&q={search_item}"
+            response = requests.get(url, timeout=self.request_timeout)
+            if response.status_code == 200:
+                parsetext = response.text.replace(("<!--"), '').replace("-->", '')
+                soup = BeautifulSoup(parsetext, "html.parser")
+                books = soup.find("div", {"id":"aarecord-list"})
+                rows = books.select("a")
+                for potential_book in rows:
+                    try:
+                        try:
+                            title_string = potential_book.find("h3").get_text().strip()
+                        except:
+                            title_string = ""
+                            
+                        try:
+                            author_string = potential_book.find("div", {"class" :"italic"}).get_text().strip()
+                        except:
+                            author_string = ""
+                        
+                        try:
+                            # contains language and file type
+                            info = potential_book.find("div", {"class" :"text-gray-500"}).get_text().strip()
+                        except:
+                            info = "english"
+                            
+                        file_type_check = any(ft.replace(".", "").lower() in info.lower() for ft in self.preferred_extensions_fiction)
+                        language_check = any(l.lower() in info.lower() for l in req_item["allowed_languages"]) or self.selected_language.lower() == "all"
+
+                        if file_type_check and language_check:
+                            author_name_match_ratio = self.compare_author_names(author, author_string)
+                            book_name_match_ratio = fuzz.ratio(title_string, book_search_text)
+                            if author_name_match_ratio >= self.minimum_match_ratio and book_name_match_ratio >= self.minimum_match_ratio:
+                                href = potential_book["href"]
+                                if href.startswith("/md5"):
+                                    found_links.append(f"http://annas-archive.org{href}")
+                    except:
+                        pass
+
+                if not found_links:
+                    req_item["status"] = "No Link Found"
+                socketio.emit("libgen_update", {"status": "Success", "data": self.libgen_items, "percent_completion": self.percent_completion})
+            else:
+                socketio.emit("libgen_update", {"status": "Error", "data": self.libgen_items, "percent_completion": self.percent_completion})
+                self.general_logger.error("Libgen Connection Error: " + str(response.status_code) + " Data: " + response.text)
+                req_item["status"] = "Libgen Error"
+                socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+        
+        except Exception as e:
+            self.general_logger.error(f"Error Searching libgen.li: {str(e)}")
+            raise Exception(f"Error Searching libgen.li: {str(e)}")
+
+        finally:
+            return found_links
+    
     def compare_author_names(self, author, author_string):
         try:
             processed_author = self.preprocess(author)
@@ -498,8 +702,16 @@ class DataHandler:
         words.sort()
         return " ".join(words)
 
-    def download_from_libgen(self, req_item, link):
-        if self.search_type.lower() == "non-fiction":
+    def download_from_mirror(self, req_item, link):
+
+        req_item["status"] = "Checking Link"
+        socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+        
+        isAnna = False
+        if "annas-archive" in link:
+            isAnna = True
+            file_type = "" # determined in aaclient.py  
+        elif self.is_using_libgen_api:
             valid_book_extensions = self.preferred_extensions_non_fiction
             link_url = link
             try:
@@ -507,42 +719,43 @@ class DataHandler:
             except:
                 file_type = None
         else:
-            valid_book_extensions = self.preferred_extensions_fiction
-            response = requests.get(link, timeout=self.request_timeout)
-            if response.status_code == 200:
-                soup = BeautifulSoup(response.text, "html.parser")
-                download_div = soup.find("div", id="download")
+            try:
+                valid_book_extensions = self.preferred_extensions_fiction
+                response = requests.get(link, timeout=self.request_timeout)
+                if response.status_code == 200:
+                    soup = BeautifulSoup(response.text, "html.parser")
+                    download_div = soup.find("div", id="download")
 
-                if download_div:
-                    download_link = download_div.find("a")
-                    if download_link:
-                        link_url = download_link.get("href")
-                    else:
-                        return "Dead Link"
-                else:
-                    table = soup.find("table")
-                    if table:
-                        rows = table.find_all("tr")
-                        for row in rows:
-                            if "GET" in row.get_text():
-                                download_link = row.find("a")
-                                if download_link:
-                                    link_text = download_link.get("href")
-                                    if "http" not in link_text:
-                                        link_url = "https://libgen.li/" + link_text
-                                    else:
-                                        link_url = link_text
-                                    break
+                    if download_div:
+                        download_link = download_div.find("a")
+                        if download_link:
+                            link_url = download_link.get("href")
                         else:
                             return "Dead Link"
                     else:
-                        return "No Link Available"
+                        table = soup.find("table")
+                        if table:
+                            rows = table.find_all("tr")
+                            for row in rows:
+                                if "GET" in row.get_text():
+                                    download_link = row.find("a")
+                                    if download_link:
+                                        link_text = download_link.get("href")
+                                        if "http" not in link_text:
+                                            link_url = "https://libgen.li/" + link_text
+                                        else:
+                                            link_url = link_text
+                                        break
+                            else:
+                                return "Dead Link"
+                        else:
+                            return "No Link Available"
 
-            else:
-                return str(response.status_code) + " : " + response.text
-
-            req_item["status"] = "Checking Link"
-            socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+                else:
+                    return str(response.status_code) + " : " + response.text
+            
+            except:
+                return "Dead Link"
 
             try:
                 file_type = os.path.splitext(link_url)[1]
@@ -551,27 +764,28 @@ class DataHandler:
                 file_type = None
                 self.general_logger.info("File extension not in url or invalid, checking link content...")
 
-        try:
-            download_response = requests.get(link_url, stream=True)
+        if not isAnna:
+            try:
+                download_response = requests.get(link_url, stream=True)
 
-        except Exception as e:
-            req_item["status"] = "Link Failed"
-            socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
-            self.general_logger.error(f"Exception {str(e)} thrown by: {link_url}")
-            return "Link Failed"
+            except Exception as e:
+                req_item["status"] = "Link Failed"
+                socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+                self.general_logger.error(f"Exception {str(e)} thrown by: {link_url}")
+                return "Link Failed"
 
-        if file_type == None or ".php" in file_type:
-            link_file_name_text = download_response.headers.get("content-disposition")
-            if not link_file_name_text:
-                return "Unknown File Type"
+            if file_type == None or ".php" in file_type:
+                link_file_name_text = download_response.headers.get("content-disposition")
+                if not link_file_name_text:
+                    return "Unknown File Type"
 
-            for ext in valid_book_extensions:
-                if ext in link_file_name_text.lower():
-                    file_type = ext
-                    break
+                for ext in valid_book_extensions:
+                    if ext in link_file_name_text.lower():
+                        file_type = ext
+                        break
 
-        if not file_type or file_type not in valid_book_extensions:
-            return "Wrong File Type"
+            if not file_type or file_type not in valid_book_extensions:
+                return "Wrong File Type"
 
         cleaned_author_name = re.sub(r"\s{2,}", " ", re.sub(r'[\\*?:"<>|]', " - ", req_item["author"].replace("/", "+")))
         cleaned_book_name = re.sub(r"\s{2,}", " ", re.sub(r'[\\*?:"<>|]', " - ", req_item["book_name"].replace("/", "+")))
@@ -616,11 +830,25 @@ class DataHandler:
         if self.libgen_stop_event.is_set():
             raise Exception("Cancelled")
 
-        if download_response.status_code == 200:
-            # Download file
-            req_item["status"] = "Downloading"
+        if not isAnna and download_response.status_code != 200:
+            req_item["status"] = "Download Error"
             socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
-
+            error_string = f"{download_response.status_code} : {download_response.text}"
+            self.general_logger.error(f"Error downloading: {os.path.basename(file_path)} - {error_string}")
+            return error_string
+        
+        socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
+        
+        if isAnna and self.aaclient is not None:
+            try:
+                req_item["status"] = "Torrenting"                
+                if self.aaclient.torrent_from_bookbounty(link, os.path.basename(file_path), os.path.dirname(file_path)):
+                    return "Success"
+            except Exception as e:
+                self.general_logger.error(f"Error downloading from Anna: {str(e)}")
+                
+        elif download_response.status_code == 200:
+            req_item["status"] = "Downloading"
             total_size = int(download_response.headers.get("content-length", 0))
             downloaded_size = 0
             chunk_counter = 0
@@ -648,18 +876,12 @@ class DataHandler:
                     os.remove(f.name)
                     self.general_logger.info(f"Removed temp file: {f.name}")
 
-            if os.path.exists(file_path):
-                self.general_logger.info(f"Downloaded: {link_url} to {file_path}")
-                return "Success"
-            else:
-                self.general_logger.info("Downloaded file not found in Directory")
-                return "Failed"
+        if os.path.exists(file_path):
+            self.general_logger.info(f"Downloaded: {link_url} to {file_path}")
+            return "Success"
         else:
-            req_item["status"] = "Download Error"
-            socketio.emit("libgen_update", {"status": self.libgen_status, "data": self.libgen_items, "percent_completion": self.percent_completion})
-            error_string = f"{download_response.status_code} : {download_response.text}"
-            self.general_logger.error(f"Error downloading: {os.path.basename(file_path)} - {error_string}")
-            return error_string
+            self.general_logger.info("Downloaded file not found in Directory")
+            return "Failed"
 
     def reset_readarr(self):
         self.readarr_stop_event.set()
@@ -706,7 +928,6 @@ class DataHandler:
         try:
             self.readarr_address = data["readarr_address"]
             self.readarr_api_key = data["readarr_api_key"]
-            self.search_type = data["search_type"]
             self.sleep_interval = float(data["sleep_interval"])
             self.sync_schedule = self.parse_sync_schedule(data["sync_schedule"])
             self.minimum_match_ratio = float(data["minimum_match_ratio"])
@@ -714,6 +935,38 @@ class DataHandler:
         except Exception as e:
             self.general_logger.error(f"Failed to update settings: {str(e)}")
 
+    def update_aaclient_settings(self):
+        try:
+            if self.aa_client_type.lower() == "hnr":
+                self.aaclient = aaclient(self.general_logger)
+                return
+            
+            if "qbittorrent" != self.aa_client_type.lower():
+                self.aaclient = None
+                return
+
+            endpoint = f"{self.readarr_address}/api/v1/downloadclient/"
+            params = {"apikey": self.readarr_api_key}
+            response = requests.get(endpoint, params=params, timeout=self.request_timeout)
+            if response.status_code == 200:
+                downloadclients = response.json()
+                current_priority = 51 # readarr max is 50
+                for dc in downloadclients:
+                    if dc["implementationName"] == "qBittorrent":
+                        if dc["priority"] > current_priority:
+                            continue
+                        current_priority = dc["priority"]
+                        download_client = {}
+                        for fields in dc["fields"]:
+                            if "name" in fields and "value" in fields:
+                                download_client[fields["name"]] = fields["value"]                
+                        self.aaclient = aaclient(self.general_logger, download_client)
+                
+        except Exception as e:
+            self.general_logger.error(f"Failed to update aaclient_settings: {str(e)}")
+            self.aaclient = None
+
+   
     def parse_sync_schedule(self, input_string):
         try:
             ret = []
@@ -734,7 +987,6 @@ class DataHandler:
         data = {
             "readarr_address": self.readarr_address,
             "readarr_api_key": self.readarr_api_key,
-            "search_type": self.search_type,
             "sleep_interval": self.sleep_interval,
             "sync_schedule": self.sync_schedule,
             "minimum_match_ratio": self.minimum_match_ratio,

--- a/src/BookBounty.py
+++ b/src/BookBounty.py
@@ -219,21 +219,20 @@ class DataHandler:
                         author = "".join(reversed(author_with_sep)).title()
                         year = item["releaseDate"][:4]
 
-                        meta_profile_id = item['author']['metadataProfileId']
+                        meta_profile_id = item["author"]["metadataProfileId"]
                         endpoint = f"{self.readarr_address}/api/v1/metadataprofile/{meta_profile_id}"
                         params = {"apikey": self.readarr_api_key}
                         response = requests.get(endpoint, params=params, timeout=self.request_timeout)
                         allowed_languages = []
                         if response.status_code == 200:
                             author_meta_profile = response.json()
-                            iso_langs = author_meta_profile["allowedLanguages"]
+                            iso_langs = author_meta_profile.get("allowedLanguages", "")
                             allowed_languages = [iso639.Lang(iso).name.lower() for iso in iso_langs.split(",") if iso639.is_language(iso)]
 
                         if allowed_languages == []:
                             self.general_logger.error(f"Readarr MetadataProfile API Error Code: {response.status_code}")
                             self.general_logger.error(f"Unable to get language from metadata profile for author: {author}\nUsing default.")
                             allowed_languages = [l.lower().strip() for l in self.selected_language.split(",")]
-
 
                         new_item = {"author": author, "book_name": title, "series": series, "checked": True, "status": "", "year": year, "allowed_languages": allowed_languages}
                         self.readarr_items.append(new_item)

--- a/src/aaclient.py
+++ b/src/aaclient.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+from bcoding import bencode, bdecode
+import hashlib
+import time, os
+from lxml import html, etree
+import requests as re
+import libtorrent as lt
+import qbittorrentapi
+
+
+book_xpaths = {"collection": "/html/body/main/div[3]/ul/li[last()]/div/a[1]",
+               "torrent": "/html/body/main/div[3]/ul/li[last()]/div/a[2]/text()",
+               "torrent_url": "/html/body/main/div[3]/ul/li[last()]/div/a[2]/@href",
+               "filename_within_torrent": "/html/body/main/div[3]/ul/li[last()]/div/text()[3]",
+               "title": "/html/body/main/div[1]/div[3]/text()",
+               "extension": "/html/body/main/div[1]/div[2]/text()"}
+
+replace_chars = str.maketrans(dict.fromkeys(''.join([" /"]), '.') | dict.fromkeys(''.join([":;"]), None))
+
+state_str = ['queued', 'checking', 'downloading metadata', \
+    'downloading', 'finished', 'seeding', 'allocating', 'checking fastresume']
+
+def file_search(torrent_info, desired_file):
+    priorities = []
+    fidx = -1
+    size = -1
+    path = ""
+    for idx, des in enumerate(torrent_info.files()):
+        if des.path.endswith(desired_file):
+            priorities.append(255)
+            fidx = idx
+            size = des.size
+            path = des.path # todo: tidy this up a bit
+        else:
+            priorities.append(0)
+    if idx == -1:
+        raise Exception("Destination file not found in torrent")
+    return (fidx, size, path, priorities)
+
+def check_torrent_completion(ses, idx):
+
+    alerts = ses.pop_alerts()
+
+    for a in alerts:
+        alert_type = type(a).__name__
+        if alert_type == "file_completed_alert":
+            if a.index == idx:
+                return True
+
+    return False
+
+def get_torrent_from_listing(url, save_as, guess_extension):
+    page = re.get(url)
+    tree = html.fromstring(page.content)
+
+    fname = tree.xpath(book_xpaths["filename_within_torrent"])[0].split('“', 1)[1][:-1]
+    t_url = tree.xpath(book_xpaths["torrent_url"])[0]
+    torrent = tree.xpath(book_xpaths["torrent"])[0][:-1][1:]
+
+    extension = tree.xpath(book_xpaths["extension"])[0].split(', ')[1]
+
+    if guess_extension:
+        save_as += extension
+    aa = url.split("/")
+    return (f"{aa[0]}//{aa[2]}{str(t_url)}", torrent, fname, save_as)
+
+def qbitt_file_search(torrent_files, desired_file):
+    for idx, des in enumerate(torrent_files):
+        if des["name"].endswith(desired_file):
+            return idx            
+    
+    raise Exception("Destination file not found in torrent")
+
+
+class aaclient:
+    def __init__(self, logger, qbitt_client = None):
+        self.logger = logger 
+        self.qbitt_client = qbitt_client    
+    
+    def hnr_download_torrent(self, t_path, desired_file, save_filename, save_path):
+        info = lt.torrent_info(t_path)
+        ses = lt.session({'listen_interfaces': '0.0.0.0:6881'})
+
+        idx, size, path, priorities = file_search(info, desired_file)
+
+        h = ses.add_torrent({'ti': info, 'save_path': save_path})
+        h.prioritize_files(priorities)
+
+        alert_mask = (lt.alert.category_t.error_notification |
+                            lt.alert.category_t.performance_warning |
+                            lt.alert.category_t.progress_notification)
+        ses.set_alert_mask(alert_mask)
+        
+        self.logger.info(f"Downloading: {save_filename} - Size: {size/1048576:.2f} MB")
+        os.remove(t_path)
+        while True:
+            s = h.status()
+            prog = h.file_progress()[idx]
+            self.logger.info(f"{prog} - {state_str[s.state]} ({s.num_peers} {'peer' if s.num_peers == 1 else 'peers'})")
+
+            if check_torrent_completion(ses, idx):
+                os.rename(save_path + "/" + path, save_path + "/" + save_filename)
+                return True
+
+            time.sleep(10)
+
+
+    def dl_torrent_from_listing(self, url, save_as):
+        self.logger.info(f"Getting torrent listing from: {url}")
+        t_url, torrent, fname, save_as = get_torrent_from_listing(url, save_as, True)
+        t = re.get(t_url, allow_redirects=True, stream=True)
+        path = f"./{torrent}"
+
+        with open(path, "wb") as fout:
+            self.logger.info(f"Downloading {torrent}")
+            for chunk in t.iter_content(chunk_size=4096):
+                fout.write(chunk)
+            self.logger.info(f"Downloaded {torrent}")
+
+        return (path, fname, save_as)
+
+
+    def qb_download_torrent(self, t_path, desired_file, save_filename):
+        conn_info = dict(
+            host=self.qbitt_client["host"],
+            port=self.qbitt_client["port"],
+            username=self.qbitt_client["username"],
+            password=self.qbitt_client["password"],
+        )
+        is_succes = False
+        try:
+            with open(t_path, "rb") as f:
+                torrent_data = f.read()
+            config = bdecode(torrent_data)
+            info = config["info"]
+            hash_bit = hashlib.sha1(bencode(info)).digest()
+            hash = hash_bit.hex()
+                
+            if len(info['files']) > 1500:
+                self.logger.error(f"This torrent has too much stuff, I don't want it. {t_path} not added to qBittorrent") 
+                is_succes = False
+                return is_succes
+                    
+            qb = qbittorrentapi.Client(**conn_info)        
+            qb.torrents_add(torrent_files=t_path, category=self.qbitt_client["musicCategory"], is_paused=True)
+            time.sleep(1) # allow metadata to be downloaded
+            
+            files = qb.torrents_files(hash)    
+            qb.torrents_file_priority(hash, [i for i in range(len(files))], priority=0) # Do not download   
+        
+            idx = qbitt_file_search(files.data, desired_file)   
+            qb.torrents_file_priority(hash, idx, 1) # Normal dl
+            new_path = os.path.dirname(files[idx].name) + "/" +  save_filename
+            qb.torrents_rename_file(hash, idx, new_path)
+            qb.torrents_start(hash)        
+            self.logger.info(f"{save_filename} added to qBittorrent")
+            is_succes = True       
+        except:
+            qb.torrents_delete(True, hash)        
+            self.logger.error(f"Error adding book. {t_path} removed from qBittorrent")
+            is_succes = False
+        finally:
+            os.remove(t_path) 
+            
+        
+        return is_succes
+        
+    def torrent_from_bookbounty(self, link, save_as, save_path):    
+        path, fname, save_as = self.dl_torrent_from_listing(link, save_as)
+        
+        if self.qbitt_client != None:            
+            return self.qb_download_torrent(path, fname, save_as)
+        else:
+            return self.hnr_download_torrent(path, fname, save_as, save_path)
+            


### PR DESCRIPTION
Made some changes to for the Format 2 Libgen sites, Figured it might be helpful for others as well. 

Reordered the link finders since all format 1 sites are now down, so the API and _is are not working. _li is now used before them. 

Made some changes to link_finder_libgen_li to correct some issues I came across. 
- Found that if a book was listed with it's series name, it was not able to resolve the title correctly. Added logic to find the title when it is buried below the series. 
- Found the generated search URL was not populating symbols with the correct encoding
- Found some books are listed as Lastname, Firstname. Added logic to check both Author name formats and use the best one to calculate the match ratio 